### PR TITLE
deprecated caching update

### DIFF
--- a/spotify.py
+++ b/spotify.py
@@ -128,13 +128,13 @@ def albu(album):
 ##################################################################
 # load data
 ##################################################################
-@st.cache
+@st.cache_data
 def load_data():
     df = pd.read_csv('spotify15k.csv')
     df.drop(["Unnamed: 0", "Unnamed: 0.1", "track_number"], axis=1, inplace=True)
     return df
 
-@st.cache
+@st.cache_data
 def convert_df(df):
      # IMPORTANT: Cache the conversion to prevent computation on every rerun
      return df.to_csv().encode('utf-8')


### PR DESCRIPTION
Updated the caching method of `load_data()` and `convert_df()`. The old caching function (`st.cache`) was deprecated in version 1.18.0 of Streamlit.